### PR TITLE
Removed NexusPrototype - no longer used in SDK

### DIFF
--- a/Source/NexusLyraIntegrationRuntime/Public/UI/CreatorSupportUserWidget.h
+++ b/Source/NexusLyraIntegrationRuntime/Public/UI/CreatorSupportUserWidget.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "NexusPrototype.h"
 #include "GameFramework/SaveGame.h"
 #include "Generated/AttributionAPI.h"
 #include "Generated/ReferralAPI.h"


### PR DESCRIPTION
While working through the documentation I was having issues getting the Lyra example to build. Upon further investigation, the examples were referencing a header file that no longer existed. I have confirmed this file was only necessary while development took place on the SDK generator. This reference was missed during original clean up.